### PR TITLE
Update main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -542,7 +542,7 @@ void UpdateParticleSimulation(SDL_Renderer* renderer, const std::vector<std::uni
 // Renders the brush size selection dropdown.
 void OnImGuiRenderBrushDropDown()
 {
-    const char* brushes[] =
+    static constexpr const char* brushes[] =
     {
         "brush small",
         "brush medium",
@@ -595,7 +595,7 @@ void OnImGuiRenderBrushDropDown()
 void OnImGuiRenderMaterialDropdown()
 {
     // TODO: build this from json
-    const char* materials[] = 
+    static constexpr const char* materials[] = 
     { 
         MATERIAL_NAME_NONE,
         MATERIAL_NAME_SAND,


### PR DESCRIPTION
I've added `static constexpr` to local arrays which are used as look-up tables.

This is better for performance, because the array is now a compile-time constant in static memory, rather than being created on the stack.